### PR TITLE
install for dev in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,26 @@ The rc channel corresponds to the latest build of PyRatp when the main channel i
 stable release.
 
 ### For developpers
+Editable install with conda/environment.yml is not functionning because of namespace conflict. A workaround is as follow:
 1) download the repository and change to the root directory:
 ```shell
    git clone https://github.com/openalea/PyRATP.git
    cd PyRATP
 ```
-2) install the package with pip in dev mode:
-
-PyRatp can also be installed using the environment.yml in conda:
+2) install dependencies manually with:
 ```shell
-mamba env create -f ./conda/environment.yml
+mamba -n pyratp -c conda-forge -c openalea3 openalea.plantgl openalea.mtg QtPy Compilers meson-python QtPy
 ```
+
+Build the fortran library:
+```shell
+meson setup builddir
+meson compile -C builddir
+cp builddir/src/openalea/ratp/pyratp.cpython-312-x86_64-linux-gnu.so src/openalea/ratp
+```
+
+Then add the path to `src` in your ipython or in IDE with:
+```ipython
+import sys; sys.path.extend([mypath to 'src'])
+```
+with `mypath to 'src'` the absolute path to 'PyRatp/src'


### PR DESCRIPTION
changed the installation part for dev in the readme. The pip editable install is not working with meson. Indeed the openalea namespace is overwritten.
This is a workaround but it works. 